### PR TITLE
Typo Fixes, filter disable. disable target force, remove unneeded code

### DIFF
--- a/MS Store Downloader/Form1.cs
+++ b/MS Store Downloader/Form1.cs
@@ -291,7 +291,7 @@ namespace MS_Store_Downloader
 //                    }
 //                    else
 //                        service = true;
-//                }
+                }
             }
 
             if (InvokeRequired)

--- a/MS Store Downloader/Form1.cs
+++ b/MS Store Downloader/Form1.cs
@@ -38,7 +38,7 @@ namespace MS_Store_Downloader
             {
                 case "Retail": return "retail";
                 case "Release Preview": return "RP";
-                case "Insider Flow": return "WIS";
+                case "Insider Slow": return "WIS";
                 case "Insider Fast": return "WIF";
                 default: return "retail";
             }

--- a/MS Store Downloader/Form1.cs
+++ b/MS Store Downloader/Form1.cs
@@ -270,8 +270,8 @@ namespace MS_Store_Downloader
 
             foreach (PackageInfo package in packages)
             {
-                if (package.Extension.ToLower() == ".appx" || package.Extension.ToLower() == ".appxbundle" || package.Extension.ToLower() == ".msix" || package.Extension.ToLower() == ".msixbundle" || package.Extension.ToLower() == ".exe" || package.Extension.ToLower() == ".msi")
-                {
+//                if (package.Extension.ToLower() == ".appx" || package.Extension.ToLower() == ".appxbundle" || package.Extension.ToLower() == ".msix" || package.Extension.ToLower() == ".msixbundle" || package.Extension.ToLower() == ".exe" || package.Extension.ToLower() == ".msi")
+//                {
                     if (package.Uri != null)
                     {
                         ListViewItem lvi = new ListViewItem(new string[] { package.Name + package.Extension, ConvertSize(package.Size) });
@@ -288,10 +288,10 @@ namespace MS_Store_Downloader
                             this.BeginInvoke(new Action(() => listView1.Items.Add(lvi)));
                             this.BeginInvoke(new Action(() => listView1.EndUpdate()));
                         }
-                    }
-                    else
-                        service = true;
-                }
+//                    }
+//                    else
+//                        service = true;
+//                }
             }
 
             if (InvokeRequired)

--- a/MS Store Downloader/url.xml
+++ b/MS Store Downloader/url.xml
@@ -34,7 +34,7 @@
 				<XmlUpdateFragmentType>FileUrl</XmlUpdateFragmentType>
 				<XmlUpdateFragmentType>FileDecryption</XmlUpdateFragmentType>
 			</infoTypes>
-			<deviceAttributes>BranchReadinessLevel=CB;CurrentBranch=rs_prerelease;OEMModel=Virtual Machine;FlightRing={3};AttrDataVer=21;SystemManufacturer=Microsoft Corporation;InstallLanguage=en-US;OSUILocale=en-US;InstallationType=Client;FlightingBranchName=external;FirmwareVersion=Hyper-V UEFI Release v2.5;SystemProductName=Virtual Machine;OSSkuId=48;FlightContent=Branch;App=WU;OEMName_Uncleaned=Microsoft Corporation;AppVer=10.0.19044.1889;OSArchitecture=AMD64;SystemSKU=None;UpdateManagementGroup=2;IsFlightingEnabled=1;IsDeviceRetailDemo=0;TelemetryLevel=3;OSVersion=10.0.19044.1889;DeviceFamily=Windows.Desktop;</deviceAttributes>
+			<deviceAttributes>FlightRing={3};</deviceAttributes>
 		</GetExtendedUpdateInfo2>
 	</s:Body>
 </s:Envelope>

--- a/MS Store Downloader/wu.xml
+++ b/MS Store Downloader/wu.xml
@@ -660,17 +660,10 @@
 					<XmlUpdateFragmentTypes>
 						<XmlUpdateFragmentType>Extended</XmlUpdateFragmentType>
 					</XmlUpdateFragmentTypes>
-					<Locales>
-						<string>en-US</string>
-						<string>en</string>
-					</Locales>
 				</ExtendedUpdateInfoParameters>
-				<ClientPreferredLanguages>
-					<string>en-US</string>
-				</ClientPreferredLanguages>
 				<ProductsParameters>
 					<SyncCurrentVersionOnly>false</SyncCurrentVersionOnly>
-					<DeviceAttributes>BranchReadinessLevel=CB;CurrentBranch=rs_prerelease;OEMModel=Virtual Machine;FlightRing={3};AttrDataVer=21;SystemManufacturer=Microsoft Corporation;InstallLanguage=en-US;OSUILocale=en-US;InstallationType=Client;FlightingBranchName=external;FirmwareVersion=Hyper-V UEFI Release v2.5;SystemProductName=Virtual Machine;OSSkuId=48;FlightContent=Branch;App=WU;OEMName_Uncleaned=Microsoft Corporation;AppVer=10.0.19044.1889;OSArchitecture=AMD64;SystemSKU=None;UpdateManagementGroup=2;IsFlightingEnabled=1;IsDeviceRetailDemo=0;TelemetryLevel=3;OSVersion=10.0.19044.1889;DeviceFamily=Windows.Desktop;</DeviceAttributes>
+					<DeviceAttributes>FlightRing={3};</DeviceAttributes>
 					<CallerAttributes>Interactive=1;IsSeeker=0;</CallerAttributes>
 					<Products/>
 				</ProductsParameters>


### PR DESCRIPTION
Note: This is (For the most part) UNTESTED, because I was not able to compile this, (build instructions or better yet CI/CD?) I just noticed the WIS (Insider Slow) outputs differently than on RG-ADGUARD, which it just outputted the release version of it. It was just a minor typo I noticed.

If you need help on the GitHub CI/CD thing, let me know what version of Visual Studio you are using, I can try to set it up for you. 

Tested against MS Remote Desktop. Also I enabled viewing of all packages (eappx, blockmap, etc) since they were missing, eappxbundle mainly (for xbox AFAIK). 

For the unneeded code, this was tested and working with Charles Proxy 3 (Web Debugger)