### PR TITLE
Fix Windows 8.0 (9200) Appx not showing up

### DIFF
--- a/MS Store Downloader/wu.xml
+++ b/MS Store Downloader/wu.xml
@@ -670,4 +670,4 @@
 			</parameters>
 		</SyncUpdates>
 	</s:Body>
-</s:Envelope><
+</s:Envelope>

--- a/MS Store Downloader/wu.xml
+++ b/MS Store Downloader/wu.xml
@@ -1,4 +1,4 @@
-﻿<s:Envelope
+<s:Envelope
 	xmlns:a="http://www.w3.org/2005/08/addressing"
 	xmlns:s="http://www.w3.org/2003/05/soap-envelope">
 	<s:Header>
@@ -87,8 +87,6 @@
 					<int>164852246</int>
 					<int>164852252</int>
 					<int>164852253</int>
-				</InstalledNonLeafUpdateIDs>
-				<OtherCachedUpdateIDs>
 					<int>10</int>
 					<int>17</int>
 					<int>2359977</int>
@@ -645,6 +643,8 @@
 					<int>168270833</int>
 					<int>168270834</int>
 					<int>168270835</int>
+				</InstalledNonLeafUpdateIDs>
+				<OtherCachedUpdateIDs>
 				</OtherCachedUpdateIDs>
 				<SkipSoftwareSync>false</SkipSoftwareSync>
 				<NeedTwoGroupOutOfScopeUpdates>true</NeedTwoGroupOutOfScopeUpdates>
@@ -663,11 +663,11 @@
 				</ExtendedUpdateInfoParameters>
 				<ProductsParameters>
 					<SyncCurrentVersionOnly>false</SyncCurrentVersionOnly>
-					<DeviceAttributes>FlightRing={3};</DeviceAttributes>
+					<DeviceAttributes>FlightRing={3};DeviceFamily=Windows.Desktop;</DeviceAttributes>
 					<CallerAttributes>Interactive=1;IsSeeker=0;</CallerAttributes>
 					<Products/>
 				</ProductsParameters>
 			</parameters>
 		</SyncUpdates>
 	</s:Body>
-</s:Envelope>
+</s:Envelope><


### PR DESCRIPTION
NOTE: This means I have to re-add Windows.Desktop since it will not show up otherwise, at least on the 9WZDNCRFJ3PS app. I downloaded every retail from RG and your tool with this commit and this commit matches RG, older doesn't, there should be 52 Files for all the rings downloaded bulk. Windows.Desktop also shows the Windows 8.1 RT (Arm) version of the app as well, which it did before the removal by you. Thats why I closed my PR: 5, I was able to test it later in Github Actions RDP (which we should also add CI/CD Builds to this project). Also I didn't add Windows.Desktop to the other XML files that were in there (url.xml).